### PR TITLE
feat: add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.gitattributes export-ignore
+.github/ export-ignore
+.gitignore export-ignore
+tests/ export-ignore
+art/ export-ignore


### PR DESCRIPTION
Reduce the size of the project when requiring it in other projects.


Added [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R5) to not export those directories when doing a composer install:
- `.github/`
- `.gitignore`
- `tests/`
- `art/` 