### PR TITLE
Add an Authorization header if GITHUB_TOKEN is set

### DIFF
--- a/src/Support/GitHub.php
+++ b/src/Support/GitHub.php
@@ -18,9 +18,14 @@ class GitHub implements RemoteRepositoryService
             $url = "https://api.github.com/repos/{$this->repository}/releases/latest";
             $options = [
                 'http' => [
-                    'header' => 'User-Agent: PHPacker',
+                    'header' => ['User-Agent: PHPacker'],
                 ],
             ];
+
+            if (getenv('GITHUB_TOKEN')) {
+                $options['http']['header'][] = 'Authorization: Bearer ' . getenv('GITHUB_TOKEN');
+            }
+
             $context = stream_context_create($options);
             $response = @file_get_contents($url, false, $context);
 


### PR DESCRIPTION
Hi!

I wanted to use PHPacker to create binaries for a CLI tool I'm making, but ran into an issue. PHPacker tries downloading from a GitHub repository, I assume to fetch the required runtimes. It does this, however, without any authentication. As I'm working on an IP that is constantly reaching the rate limits for anonymous requests, I need to authenticate my GitHub API calls. I've added basic support for this through this PR. If the `GITHUB_TOKEN` environment variable is set, an `Authorization` header is passed to the GitHub API, allowing the requester to use the higher rate limits for authenticated requests.