### PR TITLE
explicitly add serializable-closure as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "symfony/filesystem": "^7",
         "symfony/finder": "^7",
         "symfony/event-dispatcher": "^7",
-        "vlucas/phpdotenv": "^5.6"
+        "vlucas/phpdotenv": "^5.6",
+        "laravel/serializable-closure": "^2.0"
     },
     "require-dev": {
         "laravel/pint": "^1.20",


### PR DESCRIPTION
When using PHPacker inside a Laravel Zero project it would complain about missing the serializable-closure package.

It's dubious that it just works other projects. Adding it to composer.json explicitly fixes it in my case.

See #39 for more details