### PR TITLE
Refactor GitHub service to use cURL for robust error handling

### DIFF
--- a/src/Support/GitHub.php
+++ b/src/Support/GitHub.php
@@ -47,7 +47,9 @@ class GitHub implements RemoteRepositoryService
             $response = curl_exec($ch);
             $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $error = curl_error($ch);
-            curl_close($ch);
+
+            // PHP 8.0+ automatically closes the CurlHandle when $ch goes out of scope.
+            // Explicit curl_close() is deprecated in PHP 8.5+.
 
             // Handle connection-level failures (DNS, SSL, Timeout)
             if ($response === false) {
@@ -121,10 +123,18 @@ class GitHub implements RemoteRepositoryService
         $success = curl_exec($ch);
         $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $error = curl_error($ch);
-        curl_close($ch);
+
+        // PHP 8.0+ automatically handles resource cleanup for CurlHandle objects.
+        // Removed curl_close($ch).
+
         fclose($fp);
 
         if (! $success || $statusCode >= 400) {
+            // Clean up the empty/corrupted file if download failed
+            if (file_exists($zipPath)) {
+                @unlink($zipPath);
+            }
+
             $reason = $error ?: "HTTP Status {$statusCode}";
             throw new RepositoryRequestException("Failed to download release assets from '{$downloadUrl}': {$reason}");
         }

--- a/src/Support/GitHub.php
+++ b/src/Support/GitHub.php
@@ -8,74 +8,133 @@ use PHPacker\PHPacker\Exceptions\RepositoryRequestException;
 
 class GitHub implements RemoteRepositoryService
 {
+    /**
+     * @param  string  $repository  The GitHub repository (e.g., "vendor/repo")
+     */
     public function __construct(
         protected string $repository,
     ) {}
 
+    /**
+     * Fetch the latest release data from the GitHub API using cURL.
+     *
+     * @throws RepositoryRequestException
+     */
     public function releaseData(): ?array
     {
         return once(function () {
             $url = "https://api.github.com/repos/{$this->repository}/releases/latest";
-            $options = [
-                'http' => [
-                    'header' => ['User-Agent: PHPacker'],
-                ],
+
+            $ch = curl_init($url);
+
+            $headers = [
+                'User-Agent: PHPacker',
+                'Accept: application/vnd.github.v3+json',
             ];
 
             if ($_ENV['GITHUB_TOKEN'] ?? false) {
-                $options['http']['header'][] = 'Authorization: Bearer ' . $_ENV['GITHUB_TOKEN'];
+                $headers[] = 'Authorization: Bearer ' . $_ENV['GITHUB_TOKEN'];
             }
 
-            $context = stream_context_create($options);
-            $response = @file_get_contents($url, false, $context);
+            curl_setopt_array($ch, [
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_HTTPHEADER => $headers,
+                CURLOPT_FOLLOWLOCATION => true,
+                CURLOPT_TIMEOUT => 30,
+                CURLOPT_FAILONERROR => false, // We want to capture the body on 4xx/5xx
+            ]);
 
+            $response = curl_exec($ch);
+            $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $error = curl_error($ch);
+            curl_close($ch);
+
+            // Handle connection-level failures (DNS, SSL, Timeout)
             if ($response === false) {
-                throw new RepositoryRequestException("Failed to fetch release data for: {$this->repository}");
+                throw new RepositoryRequestException("Failed to connect to GitHub for '{$this->repository}': {$error}");
             }
 
-            return json_decode($response, true);
+            $data = json_decode($response, true);
+
+            // Handle API-level failures (404, 403 Rate Limit, etc.)
+            if ($statusCode >= 400) {
+                $errorMessage = $data['message'] ?? 'No error message provided by API';
+                $docsUrl = isset($data['documentation_url']) ? " (See: {$data['documentation_url']})" : '';
+
+                throw new RepositoryRequestException(
+                    "GitHub API Error [{$statusCode}] for '{$this->repository}': {$errorMessage}{$docsUrl}"
+                );
+            }
+
+            return $data;
         });
     }
 
+    /**
+     * Download the source code zipball for the latest release.
+     *
+     * @return string Path to the downloaded zip file
+     *
+     * @throws RepositoryRequestException
+     */
     public function downloadReleaseAssets(string $destination): string
     {
-        $context = stream_context_create([
-            'http' => [
-                'header' => 'User-Agent: PHPacker',
-            ],
-        ]);
+        $release = $this->releaseData();
+
+        if (! isset($release['zipball_url'])) {
+            throw new RepositoryRequestException("Release data for '{$this->repository}' is missing the 'zipball_url'.");
+        }
 
         $zipPath = Path::join($destination, 'latest.zip');
-        $downloadUrl = $this->releaseData()['zipball_url'];
+        $downloadUrl = $release['zipball_url'];
 
-        // Make sure zip file is present & empty
-        file_put_contents($zipPath, '');
-
-        // Open streams to resources
-        $remoteStream = fopen($downloadUrl, 'r', context: $context);
-        $localStream = fopen($zipPath, 'w');
-
-        if ($remoteStream === false) {
-            throw new RepositoryRequestException("Failed to open stream to release assets at '{$downloadUrl}'");
+        // Ensure the directory exists
+        if (! is_dir($destination)) {
+            mkdir($destination, 0755, true);
         }
 
-        if ($localStream === false) {
-            throw new RepositoryRequestException("Failed to open stream to '{$zipPath}'");
+        $fp = fopen($zipPath, 'w+');
+        if ($fp === false) {
+            throw new RepositoryRequestException("Failed to create local file at '{$zipPath}'");
         }
 
-        // Keep it simple
-        try {
-            if (! stream_copy_to_stream($remoteStream, $localStream)) {
-                throw new RepositoryRequestException("Failed to copy stream to '{$zipPath}'");
-            }
+        $ch = curl_init($downloadUrl);
 
-            return $zipPath;
-        } finally {
-            fclose($remoteStream);
-            fclose($localStream);
+        $headers = [
+            'User-Agent: PHPacker',
+        ];
+
+        if ($_ENV['GITHUB_TOKEN'] ?? false) {
+            $headers[] = 'Authorization: Bearer ' . $_ENV['GITHUB_TOKEN'];
         }
+
+        curl_setopt_array($ch, [
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_RETURNTRANSFER => false,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_CONNECTTIMEOUT => 20,
+            CURLOPT_TIMEOUT => 300, // Longer timeout for downloads
+            CURLOPT_FILE => $fp,
+            CURLOPT_HTTPHEADER => $headers,
+        ]);
+
+        $success = curl_exec($ch);
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+        fclose($fp);
+
+        if (! $success || $statusCode >= 400) {
+            $reason = $error ?: "HTTP Status {$statusCode}";
+            throw new RepositoryRequestException("Failed to download release assets from '{$downloadUrl}': {$reason}");
+        }
+
+        return $zipPath;
     }
 
+    /**
+     * Get the latest version tag name.
+     */
     public function latestVersion(): ?string
     {
         $response = $this->releaseData();


### PR DESCRIPTION
Thank you so much for this awesome repo.

Replaced `file_get_contents()` and PHP stream wrappers with `cURL` to resolve the `Failed to open stream: HTTP request failed! error`.

**Changes**:
- Switched to cURL for API requests and asset downloads.
- Improved error reporting by capturing specific HTTP status codes and GitHub API error messages.
- Optimized download logic using CURLOPT_FILE for better memory management.